### PR TITLE
Fix tailwindcss integration

### DIFF
--- a/resources/views/inertia_layout.edge
+++ b/resources/views/inertia_layout.edge
@@ -5,59 +5,6 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="preconnect" href="https://fonts.bunny.net">
-  <link href="https://fonts.bunny.net/css?family=instrument-sans:400,400i,500,500i,600,600i,700,700i" rel="stylesheet" />
-
-  <style>
-    :root {
-      --sand-1: #fdfdfc;
-      --sand-2: #f9f9f8;
-      --sand-3: #f1f0ef;
-      --sand-4: #e9e8e6;
-      --sand-5: #e2e1de;
-      --sand-6: #dad9d6;
-      --sand-7: #cfceca;
-      --sand-8: #bcbbb5;
-      --sand-9: #8d8d86;
-      --sand-10: #82827c;
-      --sand-11: #63635e;
-      --sand-12: #21201c;
-    }
-  </style>
-
-  <script src="https://cdn.tailwindcss.com"></script>
-
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          fontFamily: {
-            sans: ['Instrument Sans', 'sans-serif'],
-          },
-          colors: {
-            primary: {
-              DEFAULT: '#5A45FF',
-            },
-            sand: {
-              1: 'var(--sand-1)',
-              2: 'var(--sand-2)',
-              3: 'var(--sand-3)',
-              4: 'var(--sand-4)',
-              5: 'var(--sand-5)',
-              6: 'var(--sand-6)',
-              7: 'var(--sand-7)',
-              8: 'var(--sand-8)',
-              9: 'var(--sand-9)',
-              10: 'var(--sand-10)',
-              11: 'var(--sand-11)',
-              12: 'var(--sand-12)',
-            },
-          },
-        },
-      },
-    }
-  </script>
-
   @vite(['inertia/app/app.ts', `inertia/pages/${page.component}.vue`])
   @inertiaHead()
 </head>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ export default {
   prefix: '',
 
   content: [
-    '/inertia/{pages,components,app,layouts}/**/*.{ts,tsx,vue}',
+    './inertia/{pages,components,app,layouts}/**/*.{ts,tsx,vue}',
     './resources/views/**/*.edge',
   ],
 


### PR DESCRIPTION
Alright, I was able to figure out what was going on with your styling. The navigation was still there and in the markup, the missing TailwindCSS classes from fix 1 below, however, were causing them to be hidden. Then, things were discolored because TailwindCSS was configured twice (fix 2); once via PostCSS/Vite, and another via the TailwindCSS CDN.

#### Fix 1
Within the `tailwind.config.js` content array, the Inertia path wasn't relative (missing .) which resulted in PurgeCSS omitting all TailwindCSS classes used within the `inertia` directory.

#### Fix 2
Removed the CDN TailwindCSS implementation from the Inertia starter kit in favor of the prod-ready integration via PostCSS & Vite. TailwindCSS being configured twice was what was causing the purple button and other discoloring.